### PR TITLE
Make the module compatible with Node v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "gypfile": true,
   "dependencies": {
     "mocha": "^2.2.5",
-    "nan": "^1.4.1",
+    "nan": "^2.0.9",
     "should": "^7.1.0"
   }
 }


### PR DESCRIPTION
Hi Jen,

Node-userid doesn't compile with Node v4.0.0 stable, released September the 8th.
This PR takes the chance to use Nan 2.0.9, allowing the module to compile with the current Node release. It also compiles with an old Node v0.10.29, so I'm pretty confident intermediate versions work as well.

It mainly replaces the deprecated Nan APIs.

Perhaps should you bump the module's version consequently.
