### PR TITLE
Allow running against a Debug build of userid.node

### DIFF
--- a/lib/userid.js
+++ b/lib/userid.js
@@ -1,5 +1,9 @@
 var path = require('path');
-var _userid = require(path.join(__dirname, '../build/Release/userid.node'));
+try {
+    var _userid = require(path.join(__dirname, '../build/Release/userid.node'));
+} catch (e) {
+    var _userid = require(path.join(__dirname, '../build/Debug/userid.node'));
+}
 
 /**
  * Get uid and gid for user.


### PR DESCRIPTION
I've run into a problem where userid doesn't run, because I compiled node with --debug. When doing that, node-gyp compiles userid using a debug build too.

On https://github.com/nodejs/node-gyp/issues/743, it was mentioned to fall back to the Debug build if the Release build wasn't there, which is what this does too. 
As a check, I've run the unit tests after having run 'npm install -- --debug', and now they pass (without this commit, that's not working).
