### PR TITLE
Fix compiling under TrueOS 12-Current

### DIFF
--- a/src/userid.cc
+++ b/src/userid.cc
@@ -6,7 +6,13 @@
 #include <sys/types.h>
 #include <grp.h>
 #include <pwd.h>
-
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#include <sys/param.h>
+#if defined(BSD)
+	/* BSD needs unistd.h for getgrouplist function*/
+#include <unistd.h>
+#endif
+#endif
 #include <nan.h>
 
 using v8::FunctionTemplate;


### PR DESCRIPTION
BSD has the getgrouplist function in unistd, even it's may not on every BSD the same.
https://www.freebsd.org/cgi/man.cgi?query=getgrouplist&sektion=3&apropos=0&manpath=freebsd
Tested with TrueOS-Server-2016-08-31-x64
