### PR TITLE
Tell npm to not even try to install this package on Windows systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.1",
   "description": "Lookup uid and gid information in node.js. Uses native POSIX bindings, not processes.",
   "main": "lib/userid.js",
+  "os" : [ "!win32" ],
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha",
     "install": "node-gyp rebuild"


### PR DESCRIPTION
When using this package as an optional dependency, it is helpful to have `os` defined in `package.json` so that npm doesn't even try to install this package on systems that are known to fail.